### PR TITLE
Support duration and max size options

### DIFF
--- a/test/test_bag_merging.py
+++ b/test/test_bag_merging.py
@@ -86,7 +86,9 @@ def generate_input_bag(
 
 def merge_bags(inputs, merged_name, binary_path):
     print(f'Merging bags {inputs} into {merged_name}')
-    command = [os.path.join(binary_path, 'merge_bags')] + inputs + ['-o', merged_name]
+    command = [
+        os.path.join(binary_path, 'merge_bags')
+    ] + inputs + ['-o', merged_name] + ["-d", "1"]
     result = subprocess.run(command, capture_output=True, text=True)
     if result.returncode != 0:
         print(f'Failed to merge {inputs} into bag {merged_name}:\n'


### PR DESCRIPTION
- Add optional flags for max size and max duration equivalent to the bag record API
- Correct output to display progress
- Adjust minimum arguments to 1 input file. Can be used to split a single bag by size

Lint and test